### PR TITLE
Renamed classes to a nice standard

### DIFF
--- a/src/main/java/redserver/redserver/RedMain.java
+++ b/src/main/java/redserver/redserver/RedMain.java
@@ -7,27 +7,27 @@ import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
 import redserver.redserver.commands.*;
-import redserver.redserver.commands.report.Manager.ReportManager;
+import redserver.redserver.commands.report.manager.ReportManager;
 import redserver.redserver.commands.report.PlayerReport;
 import redserver.redserver.commands.report.PlayerReportMenuEvent;
 import redserver.redserver.commands.report.reports.InfoMenu.ReportsInfoEvent;
 import redserver.redserver.commands.report.reports.Reports;
 import redserver.redserver.commands.report.reports.ReportsMenu.ReportsMenuEvent;
-import redserver.redserver.commands.staffcommands.build;
-import redserver.redserver.commands.staffcommands.heal;
-import redserver.redserver.commands.staffcommands.launch;
-import redserver.redserver.commands.staffcommands.skull;
+import redserver.redserver.commands.staffcommands.BuildCommand;
+import redserver.redserver.commands.staffcommands.HealCommand;
+import redserver.redserver.commands.staffcommands.LaunchCommand;
+import redserver.redserver.commands.staffcommands.SkullGiverCommand;
 import redserver.redserver.commands.staffcommands.vanish.*;
-import redserver.redserver.commands.worlds.worldCreate;
-import redserver.redserver.commands.worlds.worldDelete;
-import redserver.redserver.commands.worlds.worldTP;
-import redserver.redserver.events.netherPortals;
-import redserver.redserver.events.worldprotection;
-import redserver.redserver.gson.gsonmanager;
-import redserver.redserver.smp.commands.home;
-import redserver.redserver.smp.commands.smptp;
-import redserver.redserver.events.onJoinEvent;
-import redserver.redserver.utilities.chatMesssages;
+import redserver.redserver.commands.worlds.CreateWorldCommand;
+import redserver.redserver.commands.worlds.DeleteWorldCommand;
+import redserver.redserver.commands.worlds.WorldTPCommand;
+import redserver.redserver.events.PortalTPManagement;
+import redserver.redserver.events.WorldProtectionListener;
+import redserver.redserver.gson.GSONManager;
+import redserver.redserver.smp.commands.HomeCommand;
+import redserver.redserver.smp.commands.SMPTeleportCommand;
+import redserver.redserver.events.PlayerJoinActions;
+import redserver.redserver.utilities.AnnouncementMessages;
 
 import java.io.File;
 import java.util.HashMap;
@@ -69,42 +69,42 @@ public final class RedMain extends JavaPlugin {
     }
 
     public void loadCommands() {
-        this.getCommand("smp").setExecutor(new smptp(this));
-        this.getCommand("hub").setExecutor(new hub(this));
-        this.getCommand("home").setExecutor(new home());
-        this.getCommand("build").setExecutor(new build());
-        this.getCommand("vanish").setExecutor(new vanish(this));
-        this.getCommand("heal").setExecutor(new heal());
-        this.getCommand("launch").setExecutor(new launch());
-        this.getCommand("skull").setExecutor(new skull());
+        this.getCommand("smp").setExecutor(new SMPTeleportCommand(this));
+        this.getCommand("hub").setExecutor(new HubTPCommand(this));
+        this.getCommand("home").setExecutor(new HomeCommand());
+        this.getCommand("build").setExecutor(new BuildCommand());
+        this.getCommand("vanish").setExecutor(new VanishCommand(this));
+        this.getCommand("heal").setExecutor(new HealCommand());
+        this.getCommand("launch").setExecutor(new LaunchCommand());
+        this.getCommand("skull").setExecutor(new SkullGiverCommand());
         this.getCommand("report").setExecutor(new PlayerReport(this));
         this.getCommand("reports").setExecutor(new Reports(this));
-        this.getCommand("wtp").setExecutor(new worldTP());
-        this.getCommand("wcreate").setExecutor(new worldCreate());
-        this.getCommand("wdelete").setExecutor(new worldDelete());
+        this.getCommand("wtp").setExecutor(new WorldTPCommand());
+        this.getCommand("wcreate").setExecutor(new CreateWorldCommand());
+        this.getCommand("wdelete").setExecutor(new DeleteWorldCommand());
     }
 
     public void loadEvents() {
         PluginManager pluginManager = this.getServer().getPluginManager();
-        pluginManager.registerEvents(new onJoinEvent(this), this);
-        pluginManager.registerEvents(new worldprotection(), this);
-        pluginManager.registerEvents(new vanish(this), this);
+        pluginManager.registerEvents(new PlayerJoinActions(this), this);
+        pluginManager.registerEvents(new WorldProtectionListener(), this);
+        pluginManager.registerEvents(new VanishCommand(this), this);
         pluginManager.registerEvents(new ReportsMenuEvent(this), this);
         pluginManager.registerEvents(new ReportsInfoEvent(this), this);
         pluginManager.registerEvents(new ReportsMenuEvent(this), this);
         pluginManager.registerEvents(new PlayerReportMenuEvent(this), this);
-        pluginManager.registerEvents(new netherPortals(), this);
+        pluginManager.registerEvents(new PortalTPManagement(), this);
     }
 
     public void loadHomes() {
         File file = new File("HomeStorage.json");
-        String content = gsonmanager.readFile(file);
+        String content = GSONManager.readFile(file);
         homeMap = gson.fromJson(content, HashMap.class);
     }
 
     public void saveHomes() {
         String toPut = gson.toJson(homeMap);
-        gsonmanager.writeFile(new File("HomeStorage.json"), toPut);
+        GSONManager.writeFile(new File("HomeStorage.json"), toPut);
     }
 
     public void loadManagers() {
@@ -119,7 +119,7 @@ public final class RedMain extends JavaPlugin {
         int sec = 20;
         int minute = sec*60;
         BukkitScheduler scheduler = this.getServer().getScheduler();
-        scheduler.runTaskTimer(this, new chatMesssages(this), 0, minute*5);
+        scheduler.runTaskTimer(this, new AnnouncementMessages(this), 0, minute*5);
     }
 
 }

--- a/src/main/java/redserver/redserver/commands/DuelsCommand.java
+++ b/src/main/java/redserver/redserver/commands/DuelsCommand.java
@@ -13,7 +13,7 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-public class duels implements CommandExecutor {
+public class DuelsCommand implements CommandExecutor {
 
 
     @Override

--- a/src/main/java/redserver/redserver/commands/HubTPCommand.java
+++ b/src/main/java/redserver/redserver/commands/HubTPCommand.java
@@ -11,10 +11,10 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import redserver.redserver.RedMain;
 
-public class hub implements CommandExecutor {
+public class HubTPCommand implements CommandExecutor {
 
     private RedMain plugin;
-    public hub(RedMain plugin) {this.plugin = plugin;}
+    public HubTPCommand(RedMain plugin) {this.plugin = plugin;}
 
 
     @Override

--- a/src/main/java/redserver/redserver/commands/PVPTPCommand.java
+++ b/src/main/java/redserver/redserver/commands/PVPTPCommand.java
@@ -12,10 +12,10 @@ import org.bukkit.entity.Player;
 import redserver.redserver.RedMain;
 import redserver.redserver.utilities.Messages;
 
-public class pvp implements CommandExecutor {
+public class PVPTPCommand implements CommandExecutor {
 
     private RedMain plugin;
-    public pvp(RedMain plugin) {this.plugin = plugin;}
+    public PVPTPCommand(RedMain plugin) {this.plugin = plugin;}
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {

--- a/src/main/java/redserver/redserver/commands/report/PlayerReportMenuEvent.java
+++ b/src/main/java/redserver/redserver/commands/report/PlayerReportMenuEvent.java
@@ -10,7 +10,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import redserver.redserver.RedMain;
-import redserver.redserver.commands.report.Manager.ReportForm;
+import redserver.redserver.commands.report.manager.ReportForm;
 
 import java.util.UUID;
 

--- a/src/main/java/redserver/redserver/commands/report/manager/ReportForm.java
+++ b/src/main/java/redserver/redserver/commands/report/manager/ReportForm.java
@@ -1,4 +1,4 @@
-package redserver.redserver.commands.report.Manager;
+package redserver.redserver.commands.report.manager;
 
 import java.util.UUID;
 

--- a/src/main/java/redserver/redserver/commands/report/manager/ReportManager.java
+++ b/src/main/java/redserver/redserver/commands/report/manager/ReportManager.java
@@ -1,4 +1,4 @@
-package redserver.redserver.commands.report.Manager;
+package redserver.redserver.commands.report.manager;
 
 import java.util.ArrayList;
 import java.util.UUID;

--- a/src/main/java/redserver/redserver/commands/report/reports/InfoMenu/ReportsInfoEvent.java
+++ b/src/main/java/redserver/redserver/commands/report/reports/InfoMenu/ReportsInfoEvent.java
@@ -1,7 +1,7 @@
 package redserver.redserver.commands.report.reports.InfoMenu;
 
 import redserver.redserver.RedMain;
-import redserver.redserver.commands.report.Manager.ReportForm;
+import redserver.redserver.commands.report.manager.ReportForm;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;

--- a/src/main/java/redserver/redserver/commands/report/reports/InfoMenu/ReportsInfoMenu.java
+++ b/src/main/java/redserver/redserver/commands/report/reports/InfoMenu/ReportsInfoMenu.java
@@ -11,7 +11,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import redserver.redserver.RedMain;
-import redserver.redserver.commands.report.Manager.ReportForm;
+import redserver.redserver.commands.report.manager.ReportForm;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/redserver/redserver/commands/report/reports/ReportsMenu/ReportsGUI.java
+++ b/src/main/java/redserver/redserver/commands/report/reports/ReportsMenu/ReportsGUI.java
@@ -9,7 +9,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import redserver.redserver.RedMain;
-import redserver.redserver.commands.report.Manager.ReportForm;
+import redserver.redserver.commands.report.manager.ReportForm;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/redserver/redserver/commands/staffcommands/BuildCommand.java
+++ b/src/main/java/redserver/redserver/commands/staffcommands/BuildCommand.java
@@ -12,7 +12,7 @@ import redserver.redserver.utilities.Messages;
 
 import java.util.ArrayList;
 
-public class build implements CommandExecutor, Listener {
+public class BuildCommand implements CommandExecutor, Listener {
 
     public static ArrayList<Player> build = new ArrayList<>();
 

--- a/src/main/java/redserver/redserver/commands/staffcommands/HealCommand.java
+++ b/src/main/java/redserver/redserver/commands/staffcommands/HealCommand.java
@@ -8,7 +8,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import redserver.redserver.utilities.Messages;
 
-public class heal implements CommandExecutor {
+public class HealCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {

--- a/src/main/java/redserver/redserver/commands/staffcommands/LaunchCommand.java
+++ b/src/main/java/redserver/redserver/commands/staffcommands/LaunchCommand.java
@@ -8,7 +8,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import redserver.redserver.utilities.Messages;
 
-public class launch implements CommandExecutor {
+public class LaunchCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
         if (label.equalsIgnoreCase("launch")) {

--- a/src/main/java/redserver/redserver/commands/staffcommands/SkullGiverCommand.java
+++ b/src/main/java/redserver/redserver/commands/staffcommands/SkullGiverCommand.java
@@ -10,7 +10,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 import redserver.redserver.utilities.Messages;
 
-public class skull implements CommandExecutor {
+public class SkullGiverCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
         if (!(sender instanceof Player)) {

--- a/src/main/java/redserver/redserver/commands/staffcommands/vanish/VanishCommand.java
+++ b/src/main/java/redserver/redserver/commands/staffcommands/vanish/VanishCommand.java
@@ -16,9 +16,9 @@ import redserver.redserver.utilities.Messages;
 
 import java.util.ArrayList;
 
-public class vanish implements CommandExecutor, Listener {
+public class VanishCommand implements CommandExecutor, Listener {
     private RedMain plugin;
-    public vanish(RedMain plugin) {this.plugin = plugin;}
+    public VanishCommand(RedMain plugin) {this.plugin = plugin;}
     public GameMode gamemode;
 
     public static ArrayList<Player> vanished = new ArrayList<Player>();

--- a/src/main/java/redserver/redserver/commands/worlds/CreateWorldCommand.java
+++ b/src/main/java/redserver/redserver/commands/worlds/CreateWorldCommand.java
@@ -10,7 +10,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import redserver.redserver.utilities.Messages;
 
-public class worldCreate implements CommandExecutor {
+public class CreateWorldCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {

--- a/src/main/java/redserver/redserver/commands/worlds/DeleteWorldCommand.java
+++ b/src/main/java/redserver/redserver/commands/worlds/DeleteWorldCommand.java
@@ -12,7 +12,7 @@ import redserver.redserver.utilities.Messages;
 
 import java.io.File;
 
-public class worldDelete implements CommandExecutor {
+public class DeleteWorldCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {

--- a/src/main/java/redserver/redserver/commands/worlds/WorldTPCommand.java
+++ b/src/main/java/redserver/redserver/commands/worlds/WorldTPCommand.java
@@ -10,7 +10,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import redserver.redserver.utilities.Messages;
 
-public class worldTP implements CommandExecutor {
+public class WorldTPCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {

--- a/src/main/java/redserver/redserver/events/DuelsListener.java
+++ b/src/main/java/redserver/redserver/events/DuelsListener.java
@@ -6,7 +6,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 
-public class duellistener implements Listener {
+public class DuelsListener implements Listener {
 
     public void onDeath(PlayerDeathEvent event) {
         Player player = event.getEntity();

--- a/src/main/java/redserver/redserver/events/PlayerJoinActions.java
+++ b/src/main/java/redserver/redserver/events/PlayerJoinActions.java
@@ -12,9 +12,9 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import redserver.redserver.RedMain;
 
-public class onJoinEvent implements Listener {
+public class PlayerJoinActions implements Listener {
     private RedMain plugin;
-    public onJoinEvent(RedMain plugin) {this.plugin = plugin;}
+    public PlayerJoinActions(RedMain plugin) {this.plugin = plugin;}
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {

--- a/src/main/java/redserver/redserver/events/PortalTPManagement.java
+++ b/src/main/java/redserver/redserver/events/PortalTPManagement.java
@@ -6,7 +6,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerPortalEvent;
 
-public class netherPortals implements Listener {
+public class PortalTPManagement implements Listener {
 
     @EventHandler
     public void onPlayerPortal(PlayerPortalEvent event) {

--- a/src/main/java/redserver/redserver/events/WorldProtectionListener.java
+++ b/src/main/java/redserver/redserver/events/WorldProtectionListener.java
@@ -12,14 +12,14 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
-import redserver.redserver.commands.staffcommands.build;
+import redserver.redserver.commands.staffcommands.BuildCommand;
 
 import java.util.ArrayList;
 
 
-public class worldprotection implements Listener {
+public class WorldProtectionListener implements Listener {
 
-    public static ArrayList<Player> builder = build.build;
+    public static ArrayList<Player> builder = BuildCommand.build;
 
 
     @EventHandler

--- a/src/main/java/redserver/redserver/gson/GSONManager.java
+++ b/src/main/java/redserver/redserver/gson/GSONManager.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 
-public class gsonmanager {
+public class GSONManager {
 
     public static String readFile(File fileName) {
         try {

--- a/src/main/java/redserver/redserver/smp/commands/HomeCommand.java
+++ b/src/main/java/redserver/redserver/smp/commands/HomeCommand.java
@@ -9,7 +9,7 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-public class home implements CommandExecutor {
+public class HomeCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 

--- a/src/main/java/redserver/redserver/smp/commands/SMPTeleportCommand.java
+++ b/src/main/java/redserver/redserver/smp/commands/SMPTeleportCommand.java
@@ -12,10 +12,10 @@ import org.bukkit.entity.Player;
 import redserver.redserver.RedMain;
 import redserver.redserver.utilities.Messages;
 
-public class smptp implements CommandExecutor {
+public class SMPTeleportCommand implements CommandExecutor {
 
     private RedMain plugin;
-    public smptp(RedMain plugin) {this.plugin = plugin;}
+    public SMPTeleportCommand(RedMain plugin) {this.plugin = plugin;}
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {

--- a/src/main/java/redserver/redserver/utilities/AnnouncementMessages.java
+++ b/src/main/java/redserver/redserver/utilities/AnnouncementMessages.java
@@ -2,10 +2,10 @@ package redserver.redserver.utilities;
 
 import redserver.redserver.RedMain;
 
-public class chatMesssages  implements Runnable {
+public class AnnouncementMessages implements Runnable {
 
     private RedMain plugin;
-    public chatMesssages(RedMain plugin) {this.plugin = plugin;}
+    public AnnouncementMessages(RedMain plugin) {this.plugin = plugin;}
 
     public int messageNumber = 0;
 


### PR DESCRIPTION
This pull request is really simple, all it does is will set the class names to their standardly used formatting (PascalCase, ExampleHere), since usually classes are easily confused for variables when both use camalCase (exampleHere), and packages tend to be lowercase