### PR TITLE
Use RedMain#get instead of initializing in constructor

### DIFF
--- a/src/main/java/redserver/redserver/RedMain.java
+++ b/src/main/java/redserver/redserver/RedMain.java
@@ -34,7 +34,7 @@ import java.util.HashMap;
 import java.util.UUID;
 
 public final class RedMain extends JavaPlugin {
-    public static RedMain plugin;
+    private static RedMain plugin;
     public static RedMain get() {return plugin;}
     private final Gson gson = new Gson();
     public ReportManager reportmanager;
@@ -48,6 +48,7 @@ public final class RedMain extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        plugin = this;
         loadCommands();
         loadEvents();
         getServer().getConsoleSender().sendMessage(ChatColor.RED + "[!] RedSpigot Has been ENABLED [!]");
@@ -68,16 +69,16 @@ public final class RedMain extends JavaPlugin {
     }
 
     public void loadCommands() {
-        this.getCommand("smp").setExecutor(new SMPTeleportCommand(this));
-        this.getCommand("hub").setExecutor(new HubTPCommand(this));
+        this.getCommand("smp").setExecutor(new SMPTeleportCommand());
+        this.getCommand("hub").setExecutor(new HubTPCommand());
         this.getCommand("home").setExecutor(new HomeCommand());
         this.getCommand("build").setExecutor(new BuildCommand());
-        this.getCommand("vanish").setExecutor(new VanishCommand(this));
+        this.getCommand("vanish").setExecutor(new VanishCommand());
         this.getCommand("heal").setExecutor(new HealCommand());
         this.getCommand("launch").setExecutor(new LaunchCommand());
         this.getCommand("skull").setExecutor(new SkullGiverCommand());
-        this.getCommand("report").setExecutor(new PlayerReport(this));
-        this.getCommand("reports").setExecutor(new Reports(this));
+        this.getCommand("report").setExecutor(new PlayerReport());
+        this.getCommand("reports").setExecutor(new Reports());
         this.getCommand("wtp").setExecutor(new WorldTPCommand());
         this.getCommand("wcreate").setExecutor(new CreateWorldCommand());
         this.getCommand("wdelete").setExecutor(new DeleteWorldCommand());
@@ -85,13 +86,13 @@ public final class RedMain extends JavaPlugin {
 
     public void loadEvents() {
         PluginManager pluginManager = this.getServer().getPluginManager();
-        pluginManager.registerEvents(new PlayerJoinActions(this), this);
+        pluginManager.registerEvents(new PlayerJoinActions(), this);
         pluginManager.registerEvents(new WorldProtectionListener(), this);
-        pluginManager.registerEvents(new VanishCommand(this), this);
-        pluginManager.registerEvents(new ReportsMenuEvent(this), this);
-        pluginManager.registerEvents(new ReportsInfoEvent(this), this);
-        pluginManager.registerEvents(new ReportsMenuEvent(this), this);
-        pluginManager.registerEvents(new PlayerReportMenuEvent(this), this);
+        pluginManager.registerEvents(new VanishCommand(), this);
+        pluginManager.registerEvents(new ReportsMenuEvent(), this);
+        pluginManager.registerEvents(new ReportsInfoEvent(), this);
+        pluginManager.registerEvents(new ReportsMenuEvent(), this);
+        pluginManager.registerEvents(new PlayerReportMenuEvent(), this);
         pluginManager.registerEvents(new PortalTPManagement(), this);
     }
 

--- a/src/main/java/redserver/redserver/commands/HubTPCommand.java
+++ b/src/main/java/redserver/redserver/commands/HubTPCommand.java
@@ -13,10 +13,6 @@ import redserver.redserver.RedMain;
 
 public class HubTPCommand implements CommandExecutor {
 
-    private RedMain plugin;
-    public HubTPCommand(RedMain plugin) {this.plugin = plugin;}
-
-
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 

--- a/src/main/java/redserver/redserver/commands/PVPTPCommand.java
+++ b/src/main/java/redserver/redserver/commands/PVPTPCommand.java
@@ -13,16 +13,10 @@ import redserver.redserver.RedMain;
 import redserver.redserver.utilities.Messages;
 
 public class PVPTPCommand implements CommandExecutor {
-
-    private RedMain plugin;
-    public PVPTPCommand(RedMain plugin) {this.plugin = plugin;}
-
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 
         ConsoleCommandSender console = Bukkit.getServer().getConsoleSender();
-
-
         if (!(sender instanceof Player)) {
             sender.sendMessage(Messages.CONSOLECANTUSE);
             return false;

--- a/src/main/java/redserver/redserver/commands/report/PlayerReport.java
+++ b/src/main/java/redserver/redserver/commands/report/PlayerReport.java
@@ -12,9 +12,6 @@ import redserver.redserver.utilities.Messages;
 
 public class PlayerReport implements CommandExecutor {
 
-    private RedMain plugin;
-    public PlayerReport(RedMain plugin) { this.plugin = plugin;}
-
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
         if (!(sender instanceof Player)){
@@ -29,15 +26,14 @@ public class PlayerReport implements CommandExecutor {
             return false;
         }
 
-        if (plugin.getServer().getPlayer(args[0]) == null) {
+        if (RedMain.get().getServer().getPlayer(args[0]) == null) {
             sender.sendMessage(ChatColor.RED + "That isn't an online player!");
             return false;
         }
 
-        Player toReport = plugin.getServer().getPlayer(args[0]);
+        Player toReport = RedMain.get().getServer().getPlayer(args[0]);
 
-        PlayerReportGui playerReportGui = new PlayerReportGui(plugin);
-        playerReportGui.reportGui((Player) sender, toReport.getPlayer().getName());
+        PlayerReportGui.reportGui((Player) sender, toReport.getPlayer().getName());
 
         sender.sendMessage(ChatColor.RED + "You have reported " + args[0] + "!");
 

--- a/src/main/java/redserver/redserver/commands/report/PlayerReportGui.java
+++ b/src/main/java/redserver/redserver/commands/report/PlayerReportGui.java
@@ -13,14 +13,9 @@ import redserver.redserver.RedMain;
 
 public class PlayerReportGui implements Listener {
 
-    private RedMain plugin;
-    public PlayerReportGui(RedMain plugin) {
-        this.plugin = plugin;
-    }
+    public static void reportGui(Player player,String toReportName) {
 
-    public void reportGui(Player player,String toReportName) {
-
-        Inventory inventory = plugin.getServer().createInventory(null, 54, ChatColor.RED + "" + ChatColor.BOLD + "Report Menu");
+        Inventory inventory = RedMain.get().getServer().createInventory(null, 54, ChatColor.RED + "" + ChatColor.BOLD + "Report Menu");
         for (int i = 0; i < 54; i++) {
             ItemStack blackGlass = new ItemStack(Material.GRAY_STAINED_GLASS, 1, (byte) 15);
             ItemMeta emptyMeta = blackGlass.getItemMeta();

--- a/src/main/java/redserver/redserver/commands/report/PlayerReportMenuEvent.java
+++ b/src/main/java/redserver/redserver/commands/report/PlayerReportMenuEvent.java
@@ -15,11 +15,6 @@ import redserver.redserver.commands.report.manager.ReportForm;
 import java.util.UUID;
 
 public class PlayerReportMenuEvent implements Listener {
-
-    private RedMain plugin;
-    public PlayerReportMenuEvent(RedMain plugin) {this.plugin = plugin;}
-
-
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
 
@@ -32,7 +27,7 @@ public class PlayerReportMenuEvent implements Listener {
             event.setCancelled(true);
             String toReportName = openedInventory.getItem(0).getItemMeta().getDisplayName();
             String senderName = openedInventory.getItem(1).getItemMeta().getDisplayName();
-            Player toReport = plugin.getServer().getPlayer(toReportName);
+            Player toReport = RedMain.get().getServer().getPlayer(toReportName);
 
 
             if (itemstack.hasItemMeta()) {

--- a/src/main/java/redserver/redserver/commands/report/reports/InfoMenu/ReportsInfoEvent.java
+++ b/src/main/java/redserver/redserver/commands/report/reports/InfoMenu/ReportsInfoEvent.java
@@ -15,9 +15,6 @@ import java.util.UUID;
 
 public class ReportsInfoEvent implements Listener {
 
-    private RedMain plugin;
-    public ReportsInfoEvent(RedMain plugin) {this.plugin = plugin;}
-
     @EventHandler
     public void invClick(InventoryClickEvent event) {
         Player player = (Player) event.getWhoClicked();
@@ -26,11 +23,11 @@ public class ReportsInfoEvent implements Listener {
 
         if (event.getView().getTitle().equals(ChatColor.RED + "Player Report!")) {
             String id = ChatColor.stripColor(inv.getItem(0).getItemMeta().getLore().toString().substring(4));
-            ReportForm reportForms = plugin.getReportManager().getReportFormByID(UUID.fromString(ChatColor.stripColor(id.substring(4))));
+            ReportForm reportForms = RedMain.get().getReportManager().getReportFormByID(UUID.fromString(ChatColor.stripColor(id.substring(4))));
             if (item != null && item.getType() != Material.AIR) {
                 if (item.hasItemMeta()) {
                     if (item.getItemMeta().getDisplayName().equals(ChatColor.GREEN + "Accept!")) {
-                        plugin.getReportManager().removeReport(new ReportForm(reportForms.getReporterName(), reportForms.getReporterName(), reportForms.getReason(), reportForms.getReportId()));
+                        RedMain.get().getReportManager().removeReport(new ReportForm(reportForms.getReporterName(), reportForms.getReporterName(), reportForms.getReason(), reportForms.getReportId()));
 
                     }
                 }

--- a/src/main/java/redserver/redserver/commands/report/reports/InfoMenu/ReportsInfoMenu.java
+++ b/src/main/java/redserver/redserver/commands/report/reports/InfoMenu/ReportsInfoMenu.java
@@ -19,15 +19,9 @@ import java.util.List;
 import java.util.UUID;
 
 public class ReportsInfoMenu implements Listener {
+    public static void playereport(String lore3, Player player) {
 
-    private RedMain plugin;
-    public ReportsInfoMenu(RedMain plugin) { this.plugin = plugin; }
-
-
-
-    public void playereport(String lore3, Player player) {
-
-        ReportForm reportForms = plugin.getReportManager().getReportFormByID(UUID.fromString(lore3.substring(4)));
+        ReportForm reportForms = RedMain.get().getReportManager().getReportFormByID(UUID.fromString(lore3.substring(4)));
 
         Inventory reports = Bukkit.createInventory(null, 54, ChatColor.RED + "Player Report!");
 
@@ -61,7 +55,7 @@ public class ReportsInfoMenu implements Listener {
         decline.setItemMeta(declineMeta);
         reports.setItem(32, decline);
 
-        plugin.getLogger().info(lore3);
+        RedMain.get().getLogger().info(lore3);
 
 
         ItemStack id = new ItemStack(Material.WHITE_WOOL);

--- a/src/main/java/redserver/redserver/commands/report/reports/Reports.java
+++ b/src/main/java/redserver/redserver/commands/report/reports/Reports.java
@@ -12,9 +12,6 @@ import redserver.redserver.utilities.Messages;
 
 public class Reports implements CommandExecutor {
 
-    private RedMain plugin;
-    public Reports(RedMain plugin) {this.plugin = plugin;}
-
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 
@@ -28,8 +25,7 @@ public class Reports implements CommandExecutor {
             return false;
         }
 
-        ReportsGUI reportsGui = new ReportsGUI(plugin);
-        reportsGui.Reports((Player) sender);
+        ReportsGUI.reports((Player) sender);
 
         return false;
     }

--- a/src/main/java/redserver/redserver/commands/report/reports/ReportsMenu/ReportsGUI.java
+++ b/src/main/java/redserver/redserver/commands/report/reports/ReportsMenu/ReportsGUI.java
@@ -16,12 +16,10 @@ import java.util.List;
 
 public class ReportsGUI implements Listener {
 
-    private RedMain plugin;
-    public ReportsGUI(RedMain plugin) { this.plugin = plugin; }
     private String id;
 
-    public void Reports(Player player) {
-        Inventory inventory = plugin.getServer().createInventory(null, 54, ChatColor.RED + "" + ChatColor.BOLD + "Reports Menu");
+    public static void reports(Player player) {
+        Inventory inventory = RedMain.get().getServer().createInventory(null, 54, ChatColor.RED + "" + ChatColor.BOLD + "Reports Menu");
 
         for(ReportForm reportform : RedMain.get().getReportManager().reportForms) {
             ItemStack itemStack = new ItemStack(Material.REDSTONE_BLOCK);

--- a/src/main/java/redserver/redserver/commands/report/reports/ReportsMenu/ReportsMenuEvent.java
+++ b/src/main/java/redserver/redserver/commands/report/reports/ReportsMenu/ReportsMenuEvent.java
@@ -16,9 +16,6 @@ import java.util.UUID;
 
 public class ReportsMenuEvent implements Listener {
 
-    private RedMain plugin;
-    public ReportsMenuEvent(RedMain plugin) {this.plugin = plugin;}
-
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
         Player player = (Player) event.getWhoClicked();
@@ -32,9 +29,8 @@ public class ReportsMenuEvent implements Listener {
                         if (event.getView().getTitle().equals(ChatColor.RED + "" + ChatColor.BOLD + "Reports Menu")) {
                             if (itemstack.getItemMeta().hasLore()) {
                                 //ReportForm reportForms = plugin.getReportManager().getReportFormByID(UUID.fromString(lore3.substring(4)));
-                                if(plugin.getReportManager().getReportFormByID(UUID.fromString(lore3.substring(4))) != null) {
-                                    ReportsInfoMenu reportsInfo = new ReportsInfoMenu(plugin);
-                                    reportsInfo.playereport(lore3, player);
+                                if(RedMain.get().getReportManager().getReportFormByID(UUID.fromString(lore3.substring(4))) != null) {
+                                    ReportsInfoMenu.playereport(lore3, player);
                                 }
                             }
                         }

--- a/src/main/java/redserver/redserver/commands/staffcommands/vanish/VanishCommand.java
+++ b/src/main/java/redserver/redserver/commands/staffcommands/vanish/VanishCommand.java
@@ -17,11 +17,9 @@ import redserver.redserver.utilities.Messages;
 import java.util.ArrayList;
 
 public class VanishCommand implements CommandExecutor, Listener {
-    private RedMain plugin;
-    public VanishCommand(RedMain plugin) {this.plugin = plugin;}
     public GameMode gamemode;
 
-    public static ArrayList<Player> vanished = new ArrayList<Player>();
+    public static ArrayList<Player> vanished = new ArrayList<>();
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
@@ -37,7 +35,7 @@ public class VanishCommand implements CommandExecutor, Listener {
 
         if (vanished.contains(player)) {
             for (Player p : Bukkit.getOnlinePlayers()) {
-                p.showPlayer(plugin, player);
+                p.showPlayer(RedMain.get(), player);
                 player.setGameMode(gamemode);
             }
             vanished.remove(player);
@@ -45,7 +43,7 @@ public class VanishCommand implements CommandExecutor, Listener {
         } else {
             for (Player p: Bukkit.getOnlinePlayers()) {
                 gamemode = player.getGameMode();
-                p.hidePlayer(plugin, player);
+                p.hidePlayer(RedMain.get(), player);
                 player.setGameMode(GameMode.CREATIVE);
             }
             vanished.add(player);
@@ -57,7 +55,7 @@ public class VanishCommand implements CommandExecutor, Listener {
     public void onJoin(PlayerJoinEvent event) {
         for(Player player : Bukkit.getOnlinePlayers()) {
             if(vanished.contains(player)) {
-                event.getPlayer().hidePlayer(plugin, player);
+                event.getPlayer().hidePlayer(RedMain.get(), player);
             }
         }
     }

--- a/src/main/java/redserver/redserver/events/PlayerJoinActions.java
+++ b/src/main/java/redserver/redserver/events/PlayerJoinActions.java
@@ -13,8 +13,6 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import redserver.redserver.RedMain;
 
 public class PlayerJoinActions implements Listener {
-    private RedMain plugin;
-    public PlayerJoinActions(RedMain plugin) {this.plugin = plugin;}
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {

--- a/src/main/java/redserver/redserver/smp/commands/SMPTeleportCommand.java
+++ b/src/main/java/redserver/redserver/smp/commands/SMPTeleportCommand.java
@@ -13,10 +13,6 @@ import redserver.redserver.RedMain;
 import redserver.redserver.utilities.Messages;
 
 public class SMPTeleportCommand implements CommandExecutor {
-
-    private RedMain plugin;
-    public SMPTeleportCommand(RedMain plugin) {this.plugin = plugin;}
-
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 


### PR DESCRIPTION
This pull request removed redundant constructors in commands and events, only intitializing the plugin variable, it instead calls `RedMain.get()` which returns an instance of the main class once it's set in the onEnable call